### PR TITLE
 inputs.conf

### DIFF
--- a/maeve_reaia_collab/openpath_linux_audittrail_ta/local/inputs.conf
+++ b/maeve_reaia_collab/openpath_linux_audittrail_ta/local/inputs.conf
@@ -1,0 +1,14 @@
+[monitor:///var/log/messages]
+sourcetype = syslog
+disabled = 0
+index = os
+
+[monitor:///var/log/audit/audit.log]
+sourcetype = linux_audit
+index = os
+disabled = 0
+
+[monitor:///var/log/secure]
+sourcetype = linux_secure
+disabled = 0
+index = os


### PR DESCRIPTION
[monitor:///var/log/messages]
sourcetype = syslog
disabled = 0
index = os

[monitor:///var/log/audit/audit.log]
sourcetype = linux_audit
index = os
disabled = 0

[monitor:///var/log/secure]
sourcetype = linux_secure
disabled = 0
index = os